### PR TITLE
removed print to screen and control of diag6_pid.enable

### DIFF
--- a/startup/csx1/plans/dark_ff.py
+++ b/startup/csx1/plans/dark_ff.py
@@ -2,7 +2,8 @@
 
 import bluesky.plans as bp
 import bluesky.plan_stubs as bps
-from ..startup.optics import inout
+from ..startup.optics import inout, diag6_pid
+
 from ..startup.detectors import fccd
 
 

--- a/startup/csx1/plans/dark_ff.py
+++ b/startup/csx1/plans/dark_ff.py
@@ -89,7 +89,7 @@ The pre-count shutter & gain states preserved.
         #        1/acq_time, acq_time))
 
         #print('\tCurrent number of images = {}.\n'.format(oldnumim))
-        yield from mv(diag6_pid.enable, 0) #turn feedback off to stop beam mis-steer
+        yield from bps.mv(diag6_pid.enable, 0) #turn feedback off to stop beam mis-steer
         yield from bps.sleep(.3) #TODO needed to make sure that the readback is changed im time for numim
 
         if numim is not None:
@@ -211,7 +211,7 @@ def ct_dark_all(numim=None, detectors=None):
         #print('\tCurrent number of images = {}.\n'.format(oldnumim))
 
         yield from bps.sleep(.3)
-        yield from mv(diag6_pid.enable, 0) #turn feedback off to stop beam mis-steer
+        yield from bps.mv(diag6_pid.enable, 0) #turn feedback off to stop beam mis-steer
 
         if numim is not None:
             #print('\tSetting to {} images.\n'.format(numim))


### PR DESCRIPTION
this prevents mis-steering of beam on the exit slit (and reduces print to screen noise)