### PR TITLE
MNT: Change env pipelines to closest to current and future

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,21 +7,15 @@ resources:
       endpoint: github
 
 jobs:
-  - template: nsls2-collection-2021-2.2.yml@templates
+  - template: 2022-2.2-py39-tiled.yml@templates
     parameters:
       beamline_acronym: CSX
-  - template: nsls2-collection-2021-2.2-py39.yml@templates
+  - template: 2022-3.1-py39-tiled.yml@templates
     parameters:
       beamline_acronym: CSX
-  - template: nsls2-collection-2021-3.1-py37.yml@templates
+  - template: 2023-1.2-py39-tiled.yml@templates
     parameters:
       beamline_acronym: CSX
-  - template: nsls2-collection-2021-3.1-py39.yml@templates
-    parameters:
-      beamline_acronym: CSX
-  - template: nsls2-collection-2022-1.0-py37.yml@templates
-    parameters:
-      beamline_acronym: CSX
-  - template: nsls2-collection-2022-1.0-py39.yml@templates
+  - template: 2023-1.2-py310-tiled.yml.yml@templates
     parameters:
       beamline_acronym: CSX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,6 @@ jobs:
   - template: 2023-1.2-py39-tiled.yml@templates
     parameters:
       beamline_acronym: CSX
-  - template: 2023-1.2-py310-tiled.yml.yml@templates
+  - template: 2023-1.2-py310-tiled.yml@templates
     parameters:
       beamline_acronym: CSX


### PR DESCRIPTION
There was no `2022-2.1-py39-tiled`, So I went with 2022-2.2. 
Also added the last env for 2022, and the most recent available for 2023 in both 3.9 and 3.10.