### PR TITLE
feat: add bec that show redundant tick labels in plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,9 @@ target/
 # PyCharm
 .idea/
 
+#VSCode
+.vscode/
+
 #ipython notebook stuff
 .ipynb_checkpoints/
 

--- a/startup/00-nsls2-tools.py
+++ b/startup/00-nsls2-tools.py
@@ -44,9 +44,10 @@ import nslsii
 from IPython import get_ipython
 from bluesky.utils import PersistentDict
 from pathlib import Path
+from csx1.analysis.callbacks import BECwithTicks
 
 ip = get_ipython()
-nslsii.configure_base(ip.user_ns, 'csx', publish_documents_with_kafka=True)
+nslsii.configure_base(ip.user_ns, 'csx', publish_documents_with_kafka=True, bec=False)
 nslsii.configure_olog(ip.user_ns)
 
 # Commenting out the DAMA-suggested location
@@ -55,6 +56,9 @@ nslsii.configure_olog(ip.user_ns)
 # runengine_metadata_dir = appdirs.user_data_dir(appname="bluesky") / Path("runengine-metadata")
 runengine_metadata_dir = os.path.expanduser("/nsls2/data/csx/shared/config/RE-metadata")
 RE.md = PersistentDict(runengine_metadata_dir)
+
+bec = BECwithTicks()
+RE.subscribe(bec)
 
 
 from csx1.startup import *

--- a/startup/00-nsls2-tools.py
+++ b/startup/00-nsls2-tools.py
@@ -58,6 +58,7 @@ runengine_metadata_dir = os.path.expanduser("/nsls2/data/csx/shared/config/RE-me
 RE.md = PersistentDict(runengine_metadata_dir)
 
 bec = BECwithTicks()
+peaks = bec.peaks  # just as alias for less typing
 RE.subscribe(bec)
 
 

--- a/startup/csx1/analysis/callbacks.py
+++ b/startup/csx1/analysis/callbacks.py
@@ -7,6 +7,8 @@ class BECwithTicks(BestEffortCallback):
         # Now loop through all of the set up plots and update tick params.
         # This will keep the axes aligned, but remove the assumption that you only want partial labels.
 
+        for plot in self._live_plots.get(doc["uid"], {}).values():
+            plot.ax.tick_params(labelbottom=True, labelleft=True)
         for scatter in self._live_scatters.get(doc["uid"], {}).values():
             scatter.ax.tick_params(labelbottom=True, labelleft=True)
         for grid in self._live_grids.get(doc["uid"], {}).values():

--- a/startup/csx1/analysis/callbacks.py
+++ b/startup/csx1/analysis/callbacks.py
@@ -1,0 +1,13 @@
+from bluesky.callbacks.best_effort import BestEffortCallback
+
+
+class BECwithTicks(BestEffortCallback):
+    def _set_up_plots(self, doc, stream_name, columns):
+        super()._set_up_plots(doc, stream_name, columns)
+        # Now loop through all of the set up plots and update tick params.
+        # This will keep the axes aligned, but remove the assumption that you only want partial labels.
+
+        for scatter in self._live_scatters.get(doc["uid"], {}).values():
+            scatter.ax.tick_params(labelbottom=True, labelleft=True)
+        for grid in self._live_grids.get(doc["uid"], {}).values():
+            grid.ax.tick_params(labelbottom=True, labelleft=True)


### PR DESCRIPTION
Short patch to make all of the 2d plots that get created when a descriptor document is encountered show redundant tick labels. 
![Screenshot 2024-06-25 at 3 02 00 PM](https://github.com/NSLS-II-CSX/profile_collection/assets/43007690/b3c9d31f-9d71-4eca-a76d-92620ee4b45e)
