### PR TITLE
More user functions and improvements 

### DIFF
--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -34,7 +34,17 @@ def ct_dark_all_patch(frames=None):
 
 
 def pol_L(pol, epu_cal_offset=None, epu_table_number=None):
-    
+    """A helper bluesky plan to change vertical and horizontal poloarization
+
+    Parameters:
+    -----------
+    pol : string
+        'H' or 'V' for horizontal (epu phase = 0) or vertical (epu phase = 24.6) polarization for CSX's undulator
+    epu_cal_offset : float
+        offset to tune the precice epu gap for a paricular energy using a particular epu calibration table
+    epu_table_number : int
+        epu calibration table
+    """    
 
     current_E = pgm.energy.setpoint.get()
 
@@ -59,7 +69,7 @@ def pol_L(pol, epu_cal_offset=None, epu_table_number=None):
     
     
     yield from bps.mv(diag6_pid.enable,1) # finepitch feedback ON
-    yield from bps.sleep(1)
+    yield from bps.sleep(0.1)
 
 def pol_C(pol, epu_cal_offset=-267, epu_phase=None):
     '''This circular polarization change uses the horizontal polarization table and will force this table.  
@@ -112,7 +122,15 @@ def md_info(default_md = RE.md):
         print(f'    {info:_<30} : {val}')
     print('\n\n Use \'md_info()\' or \'RE.md\' to inspect again.')
 
-def mvslt3(size=None): #TODO make a better version for slt3.pinhole child
+def mvslt3(size=None): #TODO make a better version for slt3.pinhole child    
+    """A helper bluesky plan to move to different pinhole diameters for slit 3.
+
+    Parameters:
+    -----------
+    size : int
+        pinhole size in microns.  options are 2000, 50, 20, and 10.  if None, then the current pinhole is returned.
+
+    """
     #x Mtr.OFF = 4.88, y Mtr.OFF = -0.95
     holes = {2000: (  8.800,  0.000),    #TODO eventually have IOC to track these values
                50: (  0.000,  0.000),

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -41,7 +41,7 @@ def pol_L(pol, epu_cal_offset=None, epu_table_number=None):
     pol : string
         'H' or 'V' for horizontal (epu phase = 0) or vertical (epu phase = 24.6) polarization for CSX's undulator
     epu_cal_offset : float
-        offset to tune the precice epu gap for a paricular energy using a particular epu calibration table
+        offset to tune the precise epu gap for a particular energy using a particular epu calibration table
     epu_table_number : int
         epu calibration table
     """    

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -193,10 +193,10 @@ Parameters:
 block_beam_bit : int, bool
 """
     if block_beam_bit: 
-        if inout.status.get() =="Not Inserted":
+        if inout.status.get() == "Not Inserted":
             yield from mv(inout, "In")
     else:
-        if inout.status.get() =="Inserted":
+        if inout.status.get() == "Inserted":
             yield from mv(inout, "Out")
 
 def block_beam():

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -205,7 +205,7 @@ def block_beam():
     yield from _block_beam(1)
 
 def show_beam():
-"""Helper plan to move inout to show beam."""
+    """Helper plan to move inout to show beam."""
     yield from _block_beam(0)
 
 # Convenience aliases: Don't need to memorize order of noun/verb

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -201,7 +201,7 @@ def _block_beam(block_beam_bit): ##TODO move this to a child of inout
             yield from mv(inout, "Out")
 
 def block_beam():
-"""Helper plan to move inout to block beam. Aliased to beam_block()."""
+    """Helper plan to move inout to block beam. Aliased to beam_block()."""
     yield from _block_beam(1)
 
 def show_beam():

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -186,12 +186,13 @@ def wait_for_peaks(pool_interval, timeout, peaks, peaks_fields=None):
                 yield from bps.sleep(pool_interval)
 
 def _block_beam(block_beam_bit): ##TODO move this to a child of inout
-"""Protective inout function that only moves if necessary. The EPS will always actuate on bps.mv.
+    """Protective inout function that only moves if necessary.
+    The EPS will always actuate on bps.mv.
 
-Parameters:
-------------
-block_beam_bit : int, bool
-"""
+    Parameters:
+    ------------
+    block_beam_bit : int, bool
+    """
     if block_beam_bit: 
         if inout.status.get() == "Not Inserted":
             yield from mv(inout, "In")

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -202,7 +202,9 @@ block_beam_bit : int, bool
 def block_beam():
 """Helper plan to move inout to block beam. Aliased to beam_block()."""
     yield from _block_beam(1)
+
 def show_beam():
+"""Helper plan to move inout to show beam."""
     yield from _block_beam(0)
 
 beam_block = block_beam

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -200,6 +200,7 @@ block_beam_bit : int, bool
             yield from mv(inout, "Out")
 
 def block_beam():
+"""Helper plan to move inout to block beam. Aliased to beam_block()."""
     yield from _block_beam(1)
 def show_beam():
     yield from _block_beam(0)

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -207,5 +207,6 @@ def show_beam():
 """Helper plan to move inout to show beam."""
     yield from _block_beam(0)
 
+# Convenience aliases: Don't need to memorize order of noun/verb
 beam_block = block_beam
 beam_show = show_beam

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -184,3 +184,19 @@ def wait_for_peaks(pool_interval, timeout, peaks, peaks_fields=None):
                 break
             else:
                 yield from bps.sleep(pool_interval)
+
+def _block_beam(block_beam_bit): ##TODO move this to a child of inout
+    if block_beam_bit: 
+        if inout.status.get() =="Not Inserted":
+            yield from mv(inout, "In")
+    else:
+        if inout.status.get() =="Inserted":
+            yield from mv(inout, "Out")
+
+def block_beam():
+    yield from _block_beam(1)
+def show_beam():
+    yield from _block_beam(0)
+
+beam_block = block_beam
+beam_show = show_beam

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -34,7 +34,7 @@ def ct_dark_all_patch(frames=None):
 
 
 def pol_L(pol, epu_cal_offset=None, epu_table_number=None):
-    """A helper bluesky plan to change vertical and horizontal poloarization
+    """A helper bluesky plan to change vertical and horizontal polarization
 
     Parameters:
     -----------

--- a/startup/99-helper_functions.py
+++ b/startup/99-helper_functions.py
@@ -186,6 +186,12 @@ def wait_for_peaks(pool_interval, timeout, peaks, peaks_fields=None):
                 yield from bps.sleep(pool_interval)
 
 def _block_beam(block_beam_bit): ##TODO move this to a child of inout
+"""Protective inout function that only moves if necessary. The EPS will always actuate on bps.mv.
+
+Parameters:
+------------
+block_beam_bit : int, bool
+"""
     if block_beam_bit: 
         if inout.status.get() =="Not Inserted":
             yield from mv(inout, "In")

--- a/startup/csx1/startup/settings.py
+++ b/startup/csx1/startup/settings.py
@@ -44,7 +44,8 @@ def relabel_fig(fig, new_label):
 # fccd.hints = {'fields': ['fccd_stats1_total']}
 for i in [1, 2, 3, 4, 5]:
     getattr(fccd, f'stats{i}').total.kind = 'hinted'
-fccd.mcs.read_attrs = fccd.mcs.read_attrs[0:7] #silences the channels we do not use (7-32)
+# Silence the channels we do not use (7-32)
+fccd.mcs.read_attrs = fccd.mcs.read_attrs[0:7]
 
 # cam_dif.hints = {'fields' : ['cam_dif_stats3_total','cam_dif_stats1_total']}
 for i in [1, 3]:

--- a/startup/csx1/startup/settings.py
+++ b/startup/csx1/startup/settings.py
@@ -35,6 +35,8 @@ for i in [2, 3, 4, 5]:
     # getattr(sclr.channels, f'chan{i}').kind = 'normal' will remove the
     # hinted fields from LivePlot and LiveTable.
 
+
+
 def relabel_fig(fig, new_label):
     fig.set_label(new_label)
     fig.canvas.manager.set_window_title(fig.get_label())
@@ -42,6 +44,7 @@ def relabel_fig(fig, new_label):
 # fccd.hints = {'fields': ['fccd_stats1_total']}
 for i in [1, 2, 3, 4, 5]:
     getattr(fccd, f'stats{i}').total.kind = 'hinted'
+fccd.mcs.read_attrs = fccd.mcs.read_attrs[0:7] #silences the channels we do not use (7-32)
 
 # cam_dif.hints = {'fields' : ['cam_dif_stats3_total','cam_dif_stats1_total']}
 for i in [1, 3]:


### PR DESCRIPTION
- Added docstrings to common functions
- Added smarter inout "in" and "out" function because the device actuates even if it is already in requested position.  the ophyd device should be fixed instead so it has this default behavior when using `mv(inout, "In")` or `mv(inout, "Out")`. Unlikely the EPS programming will be fixed anytime soon.
- removed unused channesl from fccd.mcs.wfm.  tested in the field and it works.