### PR TITLE
Add axis roi md; Fix tolerance for acquire period; Remove out of date wait for connection code

### DIFF
--- a/startup/00-nsls2-tools.py
+++ b/startup/00-nsls2-tools.py
@@ -1,42 +1,7 @@
-###############################################################################
-# TODO: remove this block once https://github.com/bluesky/ophyd/pull/959 is
-# merged/released.
-from datetime import datetime
-from ophyd.signal import EpicsSignalBase, EpicsSignal, DEFAULT_CONNECTION_TIMEOUT
-
-def print_now():
-    return datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S.%f')
-
-def wait_for_connection_base(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
-    '''Wait for the underlying signals to initialize or connect'''
-    if timeout is DEFAULT_CONNECTION_TIMEOUT:
-        timeout = self.connection_timeout
-    # print(f'{print_now()}: waiting for {self.name} to connect within {timeout:.4f} s...')
-    start = time.time()
-    try:
-        self._ensure_connected(self._read_pv, timeout=timeout)
-        # print(f'{print_now()}: waited for {self.name} to connect for {time.time() - start:.4f} s.')
-    except TimeoutError:
-        if self._destroyed:
-            raise DestroyedError('Signal has been destroyed')
-        raise
-
-def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
-    '''Wait for the underlying signals to initialize or connect'''
-    if timeout is DEFAULT_CONNECTION_TIMEOUT:
-        timeout = self.connection_timeout
-    # print(f'{print_now()}: waiting for {self.name} to connect within {timeout:.4f} s...')
-    start = time.time()
-    self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
-    # print(f'{print_now()}: waited for {self.name} to connect for {time.time() - start:.4f} s.')
-
-EpicsSignalBase.wait_for_connection = wait_for_connection_base
-EpicsSignal.wait_for_connection = wait_for_connection
-###############################################################################
-
 from ophyd.signal import EpicsSignalBase
-# EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=10)  # old style
 EpicsSignalBase.set_defaults(timeout=10, connection_timeout=10)  # new style
+# EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=10)  # old style
+
 
 
 import appdirs

--- a/startup/csx1/devices/areadetector.py
+++ b/startup/csx1/devices/areadetector.py
@@ -317,11 +317,19 @@ class AxisCam(StandardAxisCam):
         self.ensure_acquiring = False
         # Camera is currently UInt16, the default is wrong at Int8
         self.cam.data_type.set("UInt16")
+        self.additional_timeout = 0.0
         ttime.sleep(1)
 
     def stage(self):
         # Ensure we continue acquiring in case of failure
         self.ensure_acquiring = self.cam.image_mode.get() == "Continuous" and self.cam.acquire.get() == 1
+
+        # Adjust timeout relative to acquire_time and acquire_period
+        exposure_time = self.cam.acquire_time.get()
+        acquire_period = self.cam.acquire_period.get()
+        self.additional_timeout = exposure_time + acquire_period
+        self.cam.acquire._timeout += self.additional_timeout
+
         super().stage()
 
     def unstage(self):
@@ -331,6 +339,9 @@ class AxisCam(StandardAxisCam):
             self.cam.image_mode.put("Continuous")
             ttime.sleep(1)
             self.cam.acquire.put(1)
+
+        # Adjust timeout back to original value
+        self.cam.acquire._timeout -= self.additional_timeout
 
 
 class FCCDCam(AreaDetectorCam):

--- a/startup/csx1/devices/areadetector.py
+++ b/startup/csx1/devices/areadetector.py
@@ -126,6 +126,7 @@ class AxisDetectorCam(AreaDetectorCam):
     wait_for_plugins = Cpt(EpicsSignal, "WaitForPlugins", string=True, kind="hinted")
     gain = Cpt(EpicsSignal, "GainMode", string=True, kind="config")
     tec = Cpt(EpicsSignal, "TEC", string=True, kind="config")
+    acquire_period = ADComponent(EpicsSignalWithRBV, "AcquirePeriod", tolerance=0.01, timeout=5, kind="config")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/startup/csx1/startup/detectors.py
+++ b/startup/csx1/startup/detectors.py
@@ -83,6 +83,7 @@ _setup_stats(cam_slt3)
 # TODO: Add this parameter when switch from `SingleTrigger` to `ContinuousAcquisitionTrigger``: plugin_name='hdf5'
 axis1 = AxisCam("XF:23ID1-ES{AXIS}", name='axis1')
 _setup_stats(axis1)
+### more roi metadata at the end
 
 # Setup on 2018/03/16 for correlating fCCD and sample position - worked 
 # DON'T NEED STATS to take pictures of sample/optics
@@ -162,3 +163,7 @@ configuration_attrs_list.extend(['roi' + str(i) + string for i in range(1,5) for
 for attr in configuration_attrs_list:
     getattr(cam_dif_hdf5, attr).kind='config'
 cam_dif_hdf5.configuration_attrs.extend(['roi1', 'roi2', 'roi3','roi4'])
+
+for attr in configuration_attrs_list:
+    getattr(axis1, attr).kind='config'
+axis1.configuration_attrs.extend(['roi1', 'roi2', 'roi3','roi4'])

--- a/startup/csx1/startup/settings.py
+++ b/startup/csx1/startup/settings.py
@@ -26,6 +26,9 @@ sd.baseline = [theta, delta, gamma, muR,
 
 #bec.disable_baseline() #no print to CLI, just save to datastore
 
+#axis1.cam.temperature_actual.kind = 'hinted'
+#sd.baseline.extend([axis1.cam.temperature_actual]) ## TODO we need soemthing differnt
+
 sclr.names.read_attrs=['name1','name2','name3','name4','name5','name6']  # TODO  WHAT IS THIS??? - Dan Allan
 sclr.channels.read_attrs=['chan1','chan2','chan3','chan4','chan5','chan6']
 # Old-style hints config is replaced by the new 'kind' feature

--- a/startup/csx1/startup/tardis.py
+++ b/startup/csx1/startup/tardis.py
@@ -66,6 +66,8 @@ tardis.theta.user_offset.kind = 'config' #hot fix https://github.com/bluesky/blu
 tardis.delta.user_offset.kind = 'config'
 tardis.gamma.user_offset.kind = 'config'
 
+tardis.reflections.kind = "omitted"
+
 # re-map Tardis' axis names onto what an E6C expects
 name_map = {'mu': 'theta', 'omega': 'mu', 'chi': 'chi', 'phi': 'phi', 'gamma': 'delta', 'delta': 'gamma'}
 


### PR DESCRIPTION
Tolerance added for acquire_period because the camera SDK takes frame_rate. We do `1 / acquire_period` to get the frame rate which can sometimes cause the readback value to be different.

For example, setting `acquire_period = 3.0` means that we try setting the frame rate to `1 / 3 = 0.3333333...`. The camera's SDK truncates this value to `0.330` (or something similar) which we then give back to `acquire_period` as `1 / 0.330 = 3.03`. Since the readback doesn't match the requested setpoint, it was waiting forever. With the tolerance we allow for some mismatch between the values.