### PR TITLE
HDF5 timestamps from detector

### DIFF
--- a/startup/csx1/devices/areadetector.py
+++ b/startup/csx1/devices/areadetector.py
@@ -220,6 +220,7 @@ def update_describe_typing(dic, obj):
 
 
 class HDF5PluginWithFileStorePlain(HDF5Plugin_V22, FileStoreHDF5IterativeWrite): ##SOURCED FROM BELOW FROM FCCD WITH SWMR removed
+    _default_read_attrs = ("time_stamp",)
     # Captures the datum id for the timestamp recorded in the HDF5 file
     time_stamp = Cpt(ExternalFileReference, value="", kind="normal", shape=[])
 
@@ -259,12 +260,13 @@ class HDF5PluginWithFileStorePlain(HDF5Plugin_V22, FileStoreHDF5IterativeWrite):
 
         # Update the shape that describe() will report
         # Multiple images will have multiple timestamps
-        self.time_stamp.shape = [self.get_frames_per_point()]
+        fpp = self.get_frames_per_point()
+        self.time_stamp.shape = [fpp] if fpp > 1 else []
 
         # Query for the AD_HDF5_TS timestamp
         # See https://github.com/bluesky/area-detector-handlers/blob/master/area_detector_handlers/handlers.py#L230
         resource, self._ts_datum_factory = resource_factory(
-            spec="AD_HDF5_TS",
+            spec="AD_HDF5_DET_TS",
             root=str(self.reg_root),
             resource_path=str(fn),
             resource_kwargs=resource_kwargs,


### PR DESCRIPTION
This is the profile work needed to expose timestamps written in the HDF5 file to databroker/tiled.

We still need to verify that the timestamps written in the HDF5 file are coming from the detector so we will not merge this until this verification and testing is complete.

This is built from #101 so once that is merged, we can rebase with main.